### PR TITLE
non docker postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ and to ensure reproducibility.
 
 ## Installation
 
-1. Install Docker
-
+1. Using docker (for pg server)
+    Install Docker
     On MacOS: follow [these](https://docs.docker.com/desktop/install/mac-install/) instructions.
+
+1b. Using conda or mamba to get pg server, instead of a docker container.
+    conda/mamba install postgresql pgvector
+    set PIXELTABLE_USE_LOCAL_PG=1 in your env.
 
 2. `pip install git+https://github.com/mkornacker/pixeltable`
 


### PR DESCRIPTION
It is possible to get postgres and pgvector from outside docker, in particular conda supplies both, and these are available for different platforms (osx, linux, maybe windows). 

This change enables you to signal you dont want to use the docker pg container by using an env flag, but does not assume you already set up a db server. It assumes it will find the right paths in the environment, eg bc you are running this in conda.

Idea is to eventually move to an easy install default that avoids unnecessary dependence on docker daemon running.
Tested on osx. (using conda postrgres+ pgvector). 

NB if you don't use the flag you dont need to do anything.

If you do use the flag to try it, you probably need to blow up your old .pixeltable folder or use a different home.