### PR TITLE
update to use latest pgserver 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ sqlalchemy-utils = "^0.41.1"
 autonomi-nos = {version = "^0.0.9", optional = true}
 pgvector = "^0.2.1"
 av = ">=10.0.0"
-pgserver = "0.0.3"
+pgserver = "0.0.4"
 torch = {version = ">=2.0.0", optional = true}
 torchvision = {version = ">=0.16.0", optional = true}
 pyarrow = {version = ">=13.0.1", optional = true}


### PR DESCRIPTION
1. Handles case of socket collision from re-using pgdata dir name after blowing dir up, eg in development or after upgrade.
2. Includes postgres server log in python logs when server startup fails (helpful for unblocking users)