### PR TITLE
Working example of GPT4 vision in pixeltable using b64-encoded images

### DIFF
--- a/pixeltable/exprs/inline_dict.py
+++ b/pixeltable/exprs/inline_dict.py
@@ -17,6 +17,7 @@ class InlineDict(Expr):
     Dictionary 'literal' which can use Exprs as values.
     """
     def __init__(self, d: Dict):
+        from .inline_array import InlineArray
         super().__init__(ts.JsonType())  # we need to call this in order to populate self.components
         # dict_items contains
         # - for Expr fields: (key, index into components, None)
@@ -28,6 +29,8 @@ class InlineDict(Expr):
             val = copy.deepcopy(val)
             if isinstance(val, dict):
                 val = InlineDict(val)
+            if isinstance(val, list) or isinstance(val, tuple):
+                val = InlineArray(tuple(val), force_json=True)
             if isinstance(val, Expr):
                 self.dict_items.append((key, len(self.components), None))
                 self.components.append(val)

--- a/pixeltable/functions/pil/image.py
+++ b/pixeltable/functions/pil/image.py
@@ -17,14 +17,14 @@ composite = func.make_library_function(
 
 # methods of PIL.Image.Image
 
-def _b64_encode(self: PIL.Image.Image) -> str:
+def _b64_encode(self: PIL.Image.Image, image_format: str = 'png') -> str:
     # Encode this image as a b64-encoded png.
     import io
     bytes_arr = io.BytesIO()
-    self.save(bytes_arr, format='png')
+    self.save(bytes_arr, format=image_format)
     b64_bytes = base64.b64encode(bytes_arr.getvalue())
     return b64_bytes.decode('utf-8')
-b64_encode = func.make_library_function(StringType(), [ImageType()], __name__, '_b64_encode')
+b64_encode = func.make_library_function(StringType(), [ImageType(), StringType()], __name__, '_b64_encode')
 
 def _caller_return_type(bound_args: Optional[Dict[str, Any]]) -> ColumnType:
     if bound_args is None:

--- a/pixeltable/functions/pil/image.py
+++ b/pixeltable/functions/pil/image.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 from typing import Dict, Any, Tuple, Optional
 
@@ -15,6 +16,15 @@ composite = func.make_library_function(
 
 
 # methods of PIL.Image.Image
+
+def _b64_encode(self: PIL.Image.Image) -> str:
+    # Encode this image as a b64-encoded png.
+    import io
+    bytes_arr = io.BytesIO()
+    self.save(bytes_arr, format='png')
+    b64_bytes = base64.b64encode(bytes_arr.getvalue())
+    return b64_bytes.decode('utf-8')
+b64_encode = func.make_library_function(StringType(), [ImageType()], __name__, '_b64_encode')
 
 def _caller_return_type(bound_args: Optional[Dict[str, Any]]) -> ColumnType:
     if bound_args is None:


### PR DESCRIPTION
Library function for b64 encoding of PIL images and working example of GPT4 vision in pixeltable.

Also includes a bugfix for conversion of an InlineDict to JSON when the dict contains an array as a subelement.