### PR TITLE
 Remove NUL from strings during insert

### DIFF
--- a/pixeltable/tests/test_table.py
+++ b/pixeltable/tests/test_table.py
@@ -491,6 +491,15 @@ class TestTable:
             t.insert([{'c5': np.ndarray((3, 2))}])
         assert 'expected ndarray((2, 3)' in str(exc_info.value)
 
+    def test_insert_string_with_null(self, test_client: pt.Client) -> None:
+        cl = test_client
+        t = cl.create_table('test', {'c1': StringType()})
+
+        t.insert([{'c1': 'this is a python\x00string'}])
+        assert t.count() == 1
+        for tup in t.df().collect():
+            assert tup['c1'] == 'this is a python string'
+
     def test_query(self, test_client: pt.Client) -> None:
         cl = test_client
         col_names = ['c1', 'c2', 'c3', 'c4', 'c5']

--- a/pixeltable/type_system.py
+++ b/pixeltable/type_system.py
@@ -436,6 +436,13 @@ class StringType(ColumnType):
         if not isinstance(val, str):
             raise TypeError(f'Expected string, got {val.__class__.__name__}')
 
+    def _create_literal(self, val: Any) -> Any:
+        # Replace null byte within python string with space to avoid issues with Postgres.
+        # Use a space to avoid merging words.
+        # TODO(orm): this will also be an issue with JSON inputs, would space still be a good replacement?
+        if '\x00' in val:
+            return val.replace('\x00', ' ')
+        return val
 
 class IntType(ColumnType):
     def __init__(self, nullable: bool = False):


### PR DESCRIPTION
shows up in HF datasets and its legal in python, etc. but not in Postgres.